### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/01133318/58577f27-c36e-47d0-9166-d776046c9d72/b8c46cd8-ad29-4083-8158-d84b59d074b3/_apis/work/boardbadge/1c7d0226-0595-4aa6-b9e1-2e99eadfd43d)](https://dev.azure.com/01133318/58577f27-c36e-47d0-9166-d776046c9d72/_boards/board/t/b8c46cd8-ad29-4083-8158-d84b59d074b3/Microsoft.RequirementCategory)
 # Projekt na Programowanie aplikacji mobilnych i webowych
 
 Realizacja kolejnych etapów projektów laboratoryjnych.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/01133318/58577f27-c36e-47d0-9166-d776046c9d72/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.